### PR TITLE
Handle json arrays in definitions filter

### DIFF
--- a/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/FHIRSpecParser.java
+++ b/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/FHIRSpecParser.java
@@ -116,7 +116,7 @@ public class FHIRSpecParser extends AbstractSpecParser {
                                         OperationDefinition operationDefinition = (OperationDefinition) fhirResourceEntry;
                                         FHIROperationDef operationDef = new FHIROperationDef();
                                         operationDef.setOperationDefinition(operationDefinition);
-                                        fhirImplementationGuide.getOperations().putIfAbsent(operationDefinition.getUrl(),operationDef);
+                                        fhirImplementationGuide.getOperations().putIfAbsent(operationDefinition.getUrl(), operationDef);
                                     }
                                 }
                             } else if (parsedDef instanceof CodeSystem) {
@@ -268,7 +268,7 @@ public class FHIRSpecParser extends AbstractSpecParser {
     private boolean isValidFHIRDefinition(File definitionFile) {
         try (FileReader fileReader = new FileReader(definitionFile)) {
             JsonElement jsonElement = new Gson().fromJson(fileReader, JsonElement.class);
-            if (!jsonElement.isJsonArray()){
+            if (!jsonElement.isJsonArray()) {
                 return jsonElement.getAsJsonObject().has("resourceType");
             }
         } catch (IOException e) {

--- a/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/FHIRSpecParser.java
+++ b/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/FHIRSpecParser.java
@@ -267,11 +267,13 @@ public class FHIRSpecParser extends AbstractSpecParser {
      */
     private boolean isValidFHIRDefinition(File definitionFile) {
         try (FileReader fileReader = new FileReader(definitionFile)) {
-            JsonObject jsonObject = new Gson().fromJson(fileReader, JsonObject.class);
-            return jsonObject.has("resourceType");
+            JsonElement jsonElement = new Gson().fromJson(fileReader, JsonElement.class);
+            if (!jsonElement.isJsonArray()){
+                return jsonElement.getAsJsonObject().has("resourceType");
+            }
         } catch (IOException e) {
             LOG.error("Error occurred while reading the definition file: " + definitionFile.getName(), e);
-            return false;
         }
+        return false;
     }
 }


### PR DESCRIPTION
## Purpose
> In FHIR definitions filter, JSON Syntax exceptions occur when a JSON array is validated. This will add support to filter JSON arrays as well.

## Approach
> Parse the file to JsonElement instead of JsonObject
