### PR TITLE
[CodeGen] Add FHIR Version Getter

### DIFF
--- a/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/FHIRTool.java
+++ b/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/FHIRTool.java
@@ -66,4 +66,8 @@ public class FHIRTool extends AbstractTool {
     public void setToolImplementations(Map<String, Tool> toolImplementations) {
         this.toolImplementations = toolImplementations;
     }
+
+    public String getFhirVersion(){
+        return fhirVersion;
+    }
 }


### PR DESCRIPTION
## Purpose
To introduce a FHIR version getter to the CodeGen Tool so that, a there could be a central point to initialize the the FHIR version for both health tool and codegen-tool framework.

## Goals
Centralizing the fhir version parameter from for both health tool and codegen-tool framework so that a user can refrain from passing the parameter as an argument.

## Approach
A code review relating to the FHIR Tool's extension to parse multiple fhir versions revealed that giving the user ability to specify the fhir version has the risk of inputting a mismatching version rather than the one defined in the profile files. In case of the tool will terminate from processing. 
In this approach the FHIR version is directly retrieved from the IG files and that is saved as a global parameter so that the tool run in a consistent manner.

## User stories
N/A

## Release note
Adding a FHIR version getter to the codegen-tool-framework to maintain a centralized FHIR version parameter throughout the health-tool.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Testing was done via the health-tool source implementation and at 99.98% coverage for both FHIR R4 and R5 spec parsing.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
 - Ran FindSecurityBugs plugin and verified report? No
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
[fhir-tools](https://github.com/ballerina-platform/fhir-tools/pull/112)

## Migrations (if applicable)
Applied Java 21 and Ballerina 2201.12.3 migration.

## Test environment
JDK 21
Ballerina 2201.12.3
Windows 11 Pro
 
## Learning
N/A