### PR TITLE
[codegen-tool] Add resource name for path name for aggregated template generation

### DIFF
--- a/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/oas/OASGenerator.java
+++ b/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/oas/OASGenerator.java
@@ -103,6 +103,7 @@ public class OASGenerator {
         License license = new License();
         license.setName("Apache 2.0");
         license.setUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
+
         Contact contact = new Contact();
         contact.setName("API Support");
         contact.setUrl("https://wso2.com/contact/`");
@@ -257,8 +258,8 @@ public class OASGenerator {
                     break;
             }
         }
-        paths.addPathItem("/", rootPath);
-        paths.addPathItem("/{id}", idPath);
+        paths.addPathItem("/" + apiDefinition.getResourceType(), rootPath);
+        paths.addPathItem("/" + apiDefinition.getResourceType() + "/{id}", idPath);
         apiDefinition.getOpenAPI().setPaths(paths);
     }
 }

--- a/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/versions/r4/oas/R4OASGenerator.java
+++ b/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/versions/r4/oas/R4OASGenerator.java
@@ -168,8 +168,9 @@ public class R4OASGenerator extends OASGenerator {
         extensions.put(APIDefinitionConstants.OAS_EXTENSION_OH_FHIR_PROFILE, apiDefinition.getSupportedProfiles());
         apiDefinition.getOpenAPI().setExtensions(extensions);
 
-        if (apiDefinition.getOpenAPI().getPaths().get("/") != null) {
-            Operation rootGet = apiDefinition.getOpenAPI().getPaths().get("/").getGet();
+        String resourcePath = "/" + apiDefinition.getResourceType();
+        if (apiDefinition.getOpenAPI().getPaths().get(resourcePath) != null) {
+            Operation rootGet = apiDefinition.getOpenAPI().getPaths().get(resourcePath).getGet();
 
             if (rootGet != null) {
                 for (FHIRSearchParamDef searchParamDef : FHIRR4SpecificationData.getDataHolderInstance().getInternationalSearchParameters(

--- a/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/versions/r5/oas/R5OASGenerator.java
+++ b/components/fhir-core/src/main/java/org/wso2/healthcare/codegen/tool/framework/fhir/core/versions/r5/oas/R5OASGenerator.java
@@ -164,8 +164,9 @@ public class R5OASGenerator extends OASGenerator {
         extensions.put(APIDefinitionConstants.OAS_EXTENSION_OH_FHIR_PROFILE, apiDefinition.getSupportedProfiles());
         apiDefinition.getOpenAPI().setExtensions(extensions);
 
-        if (apiDefinition.getOpenAPI().getPaths().get("/") != null) {
-            Operation rootGet = apiDefinition.getOpenAPI().getPaths().get("/").getGet();
+        String resourcePath = "/" + apiDefinition.getResourceType();
+        if (apiDefinition.getOpenAPI().getPaths().get(resourcePath) != null) {
+            Operation rootGet = apiDefinition.getOpenAPI().getPaths().get(resourcePath).getGet();
 
             if (rootGet != null) {
                 for (FHIRSearchParamDef searchParamDef : FHIRR5SpecificationData.getDataHolderInstance().getInternationalSearchParameters(apiDefinition.getResourceType())) {


### PR DESCRIPTION
## Purpose
Related to: [Monolithic Deployment of FHIR APIs](https://github.com/wso2-enterprise/open-healthcare/issues/1764)
Add resource name for API path name for individual services to identify them in aggregated mode.

## Goals

1. Change OAS so that its resource could be identified with unique path names.

## Approach
Earlier in aggregated mode of the health-tool OAS files were generated per port and per resources. By using Ballerina interceptor a single port can host multiple services by using different paths. To support this objective the aggregated mode will now create a single oas-definition file for all resources requested and thus their associated operations, search parameters etc. could be identified uniquely by the resource name. The change to codegen-tool-framework adds the resource type to API path such that operations related to a resource could be identified uniquely.

## Automation tests
N/A
Tested by integrating with the Ballerina-Health-Tool for generated OAS definitions and with Devant for their functionality.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
 - Ran FindSecurityBugs plugin and verified report? No
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Related PRs
[Add FHIR API template aggregation support for monolithic deployments](https://github.com/ballerina-platform/fhir-tools/pull/115)

## Test environment
JDK: 21
OS: Windows 11
Ballerina: 2201.12.3